### PR TITLE
Add filter helpers module for drawing and filtering points

### DIFF
--- a/filterHelpers.mjs
+++ b/filterHelpers.mjs
@@ -1,0 +1,30 @@
+let _filterEnabled = false;
+
+export function isFilterEnabled() {
+  return _filterEnabled;
+}
+
+export function setFilterEnabled(value) {
+  _filterEnabled = !!value;
+  return _filterEnabled;
+}
+
+export function toggleFilter() {
+  _filterEnabled = !_filterEnabled;
+  return _filterEnabled;
+}
+
+export function defaultPredicate(p) {
+  return typeof p?.value === "number" ? p.value >= 0 : true;
+}
+
+export function filterPoints(points, predicate = defaultPredicate) {
+  if (!Array.isArray(points)) return [];
+  return _filterEnabled ? points.filter(predicate) : points.slice();
+}
+
+export function drawPoints(points, drawPoint, predicate = defaultPredicate) {
+  const toDraw = filterPoints(points, predicate);
+  toDraw.forEach(drawPoint);
+  return toDraw.length;
+}


### PR DESCRIPTION
## Summary
- add ESM module to track filter state and provide pure helpers
- expose utilities to filter point arrays and draw them while counting

## Testing
- `node --input-type=module -e "import {isFilterEnabled,setFilterEnabled,toggleFilter,filterPoints,drawPoints} from './filterHelpers.mjs'; console.log('enabled', isFilterEnabled()); setFilterEnabled(true); const pts=[{value:1},{value:-1},{value:2}]; console.log('filtered', filterPoints(pts).length); const drawn = drawPoints(pts, p=>p); console.log('drawn', drawn);"`


------
https://chatgpt.com/codex/tasks/task_e_68a4e7fb0f6c8322b6de0813aa026bb7