### PR TITLE
Fix canvas scaling in filtered stream preview

### DIFF
--- a/filtered-stream.html
+++ b/filtered-stream.html
@@ -53,7 +53,11 @@
     navigator.mediaDevices.getUserMedia({ video: true, audio: false })
       .then((stream) => {
         video.srcObject = stream;
-        draw();
+        video.onloadedmetadata = () => {
+          canvas.width = video.videoWidth;
+          canvas.height = video.videoHeight;
+          draw();
+        };
       })
       .catch((err) => console.error('Camera error:', err));
 


### PR DESCRIPTION
## Summary
- Ensure canvas dimensions match the incoming video stream before drawing frames, preventing distorted preview in filtered-stream.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e5149cac8322b81960f11f014b35