### PR TITLE
Add shared database configuration for model dashboard

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,29 @@
+<?php
+// Shared configuration for PurePressureLive PHP endpoints.
+// Creates a PDO connection in $pdo so dashboard and API scripts
+// can query the database without duplicating boilerplate.
+
+$dsn = getenv('PPLIVE_DB_DSN');
+$dbUser = getenv('PPLIVE_DB_USER');
+$dbPass = getenv('PPLIVE_DB_PASS');
+
+if (!$dsn) {
+    $dbHost = getenv('PPLIVE_DB_HOST') ?: 'localhost';
+    $dbName = getenv('PPLIVE_DB_NAME') ?: 'purepressure';
+    $dbCharset = getenv('PPLIVE_DB_CHARSET') ?: 'utf8mb4';
+    $dsn = sprintf('mysql:host=%s;dbname=%s;charset=%s', $dbHost, $dbName, $dbCharset);
+}
+
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $dbUser, $dbPass, $options);
+} catch (PDOException $e) {
+    error_log('Database connection failed: ' . $e->getMessage());
+    http_response_code(500);
+    exit('Database connection failed.');
+}


### PR DESCRIPTION
## Summary
- add a shared `config.php` so the model dashboard can load its database connection without fatally erroring
- allow connection details to be supplied through environment variables with sensible defaults
- return a 500 response and log the error message when a database connection cannot be established

## Testing
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68db9cddcd9883228e32dddfffdec99d